### PR TITLE
update mimemagic to a non-yanked version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)


### PR DESCRIPTION
may need to install `shared-mime-info` system package to get the new version to work