### PR TITLE
Save sanitized requester names

### DIFF
--- a/app/views/main/_report.haml
+++ b/app/views/main/_report.haml
@@ -10,7 +10,7 @@
   %tr{id: "report-#{report.id}"}
     %td{:valign => "top"}
       - rid = report.requester_amzn_id.nil? ? report.requester_id.to_s : report.requester_amzn_id
-      .strong= link_to h(report.requester_amzn_name), :controller => "main", :action => "index", :id => rid
+      .strong= link_to h(raw report.requester_amzn_name), :controller => "main", :action => "index", :id => rid
       = h(report.requester_amzn_id)
       %br/
       - if Person.find(session[:person_id]).is_moderator

--- a/app/views/main/_report.haml
+++ b/app/views/main/_report.haml
@@ -10,7 +10,7 @@
   %tr{id: "report-#{report.id}"}
     %td{:valign => "top"}
       - rid = report.requester_amzn_id.nil? ? report.requester_id.to_s : report.requester_amzn_id
-      .strong= link_to h(raw report.requester_amzn_name), :controller => "main", :action => "index", :id => rid
+      .strong= link_to raw(report.requester_amzn_name), :controller => "main", :action => "index", :id => rid
       = h(report.requester_amzn_id)
       %br/
       - if Person.find(session[:person_id]).is_moderator

--- a/app/views/main/_requester.haml
+++ b/app/views/main/_requester.haml
@@ -1,7 +1,7 @@
 %tr
   %td{:valign => "top"}
     - rid = requester.amzn_requester_id.nil? ? requester.id : requester.amzn_requester_id
-    .strong= link_to h(requester.amzn_requester_name), :controller => "main", :action => "index", :id => rid
+    .strong= link_to raw(requester.amzn_requester_name), :controller => "main", :action => "index", :id => rid
     = h(requester.amzn_requester_id)
     - unless requester.amzn_requester_id.nil?
       %br/

--- a/app/views/main/add_comment.haml
+++ b/app/views/main/add_comment.haml
@@ -3,7 +3,7 @@
 .report
   %p
     %strong.label AMT Requester Name &amp; ID
-    = @report.requester_amzn_name + " (" + @report.requester_amzn_id + ")"
+    #{raw(@report.requester_amzn_name)} (#{@report.requester_amzn_id}))
   %p
     %strong.label Description
     - if !@report.description.nil?

--- a/app/views/main/edit_comment.haml
+++ b/app/views/main/edit_comment.haml
@@ -3,7 +3,7 @@
 .report
   %p
     %strong.label AMT Requester Name &amp; ID
-    = @report.requester_amzn_name + " (" + @report.requester_amzn_id + ")"
+    #{raw(@report.requester_amzn_name)} (#{@report.requester_amzn_id}))
   %p
     %strong.label Description
     = h(@report.description.censor).gsub(/\r\n/,"<br/>")

--- a/app/views/main/edit_report.haml
+++ b/app/views/main/edit_report.haml
@@ -19,7 +19,7 @@
         (A HIT violates ToS under <a href="https://www.mturk.com/mturk/help?helpPage=policies#violation_examples" style="text-decoration:underline">specific conditions</a>, not just because you're mad.)
     %p
       .label Requester Name
-      = @requester.amzn_requester_name
+      = raw(@requester.amzn_requester_name)
     %p
       .label.red Requester ID
       = @requester.amzn_requester_id

--- a/app/views/mod/_report.haml
+++ b/app/views/mod/_report.haml
@@ -13,7 +13,7 @@
       %br/
       = report.updated_at.strftime("%H:%M&nbsp;%m/%d/%y").html_safe
   %td{:valign => "top"}
-    = link_to h(report.amzn_requester_name), :controller => "main", :action => "index", :id => report.amzn_requester_id
+    = link_to raw(report.amzn_requester_name), :controller => "main", :action => "index", :id => report.amzn_requester_id
     %br/
     = report.amzn_requester_id
     %br/


### PR DESCRIPTION
Previously we prevented reports from being saved if the
requester name had any special characters that
were changed by the sanitizer. This prevents
legit requester names with ampersands,
for example, from being saved.

This solution saves the sanitized requester
name instead of the raw input then displays the
name with the right character.

It should display a requester name with an
ampersand (vs '&amp;') but still prevent script
injections