### PR TITLE
Convert tables to InnoDB and utf8mb4

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,13 +3,13 @@
 # Table name: comments
 #
 #  id              :integer          not null, primary key
-#  report_id       :integer
-#  person_id       :integer
-#  body            :text(65535)
+#  body            :text(16777215)
+#  displayed_notes :text(16777215)
+#  notes           :text(16777215)
 #  created_at      :datetime
 #  updated_at      :datetime
-#  notes           :text(65535)
-#  displayed_notes :text(65535)
+#  person_id       :integer
+#  report_id       :integer
 #
 
 class Comment < ApplicationRecord

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -3,12 +3,12 @@
 # Table name: flags
 #
 #  id              :integer          not null, primary key
-#  report_id       :integer
-#  person_id       :integer
-#  comment         :text(65535)
+#  comment         :text(16777215)
+#  displayed_notes :text(16777215)
 #  created_at      :datetime
 #  updated_at      :datetime
-#  displayed_notes :text(65535)
+#  person_id       :integer
+#  report_id       :integer
 #
 
 class Flag < ApplicationRecord

--- a/app/models/forum_post_version.rb
+++ b/app/models/forum_post_version.rb
@@ -3,14 +3,14 @@
 # Table name: forum_post_versions
 #
 #  id         :integer          not null, primary key
-#  post_id    :integer
+#  body       :text(16777215)
 #  ip         :string(255)
-#  title      :text(65535)
-#  body       :text(65535)
 #  next       :integer
+#  title      :text(16777215)
 #  created_at :datetime
 #  updated_at :datetime
 #  person_id  :integer
+#  post_id    :integer
 #
 class ForumPostVersion < ApplicationRecord
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,13 +3,13 @@
 # Table name: notifications
 #
 #  id         :integer          not null, primary key
-#  person_id  :integer
-#  title      :text(65535)
-#  body       :text(65535)
+#  body       :text(16777215)
 #  read       :boolean
 #  read_at    :datetime
+#  title      :text(16777215)
 #  created_at :datetime
 #  updated_at :datetime
+#  person_id  :integer
 #
 class Notification < ApplicationRecord
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,14 +3,14 @@
 # Table name: posts
 #
 #  id         :integer          not null, primary key
-#  person_id  :integer
-#  parent_id  :integer
-#  title      :text(65535)
-#  body       :text(65535)
+#  body       :text(16777215)
+#  is_sticky  :boolean
+#  slug       :string(255)
+#  title      :text(16777215)
 #  created_at :datetime
 #  updated_at :datetime
-#  slug       :string(255)
-#  is_sticky  :boolean
+#  parent_id  :integer
+#  person_id  :integer
 #
 
 class Post < ApplicationRecord

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -6,13 +6,13 @@
 #  amzn_requester_name :string(255)
 #  comm                :integer
 #  comment_count       :integer
-#  description         :text(65535)
-#  displayed_notes     :text(65535)
+#  description         :text(16777215)
+#  displayed_notes     :text(16777215)
 #  dont_censor         :boolean
 #  fair                :integer
 #  fast                :integer
 #  flag_count          :integer
-#  hit_names           :text(65535)
+#  hit_names           :text(16777215)
 #  how_many_hits       :string(255)
 #  ignore_count        :integer          default(0)
 #  ip                  :string(255)

--- a/app/models/rules_version.rb
+++ b/app/models/rules_version.rb
@@ -3,12 +3,12 @@
 # Table name: rules_versions
 #
 #  id                  :integer          not null, primary key
-#  parent_id           :integer
+#  body                :text(16777215)
 #  is_current          :boolean
-#  edited_by_person_id :integer
 #  created_at          :datetime
 #  updated_at          :datetime
-#  body                :text(65535)
+#  edited_by_person_id :integer
+#  parent_id           :integer
 #
 class RulesVersion < ApplicationRecord
   def parent

--- a/db/migrate/20211205222914_change_reports_to_innodb.rb
+++ b/db/migrate/20211205222914_change_reports_to_innodb.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ChangeReportsToInnodb < ActiveRecord::Migration[6.0]
+  def up
+    execute <<~SQL
+      ALTER TABLE `reports` ENGINE=InnoDB
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      ALTER TABLE `reports` ENGINE=MyISAM
+    SQL
+  end
+end

--- a/db/migrate/20211205223503_convert_to_utf8_mb4.rb
+++ b/db/migrate/20211205223503_convert_to_utf8_mb4.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class ConvertToUtf8Mb4 < ActiveRecord::Migration[6.0]
+  TABLES = %w[
+    aliases
+    comments
+    flags
+    follows
+    forum_person_info
+    forum_post_versions
+    forum_posts
+    ignores
+    notifications
+    people
+    posts
+    reports
+    reputation_statements
+    requesters
+    rules_versions
+  ].freeze
+
+  def up
+    TABLES.each do |table|
+      execute "ALTER TABLE `#{table}` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+    end
+  end
+
+  def down
+    TABLES.each do |table|
+      execute "ALTER TABLE `#{table}` CONVERT TO CHARACTER SET latin1 COLLATE latin1_swedish_ci"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_24_192202) do
+ActiveRecord::Schema.define(version: 2021_12_05_222914) do
 
   create_table "aliases", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "requester_id"
@@ -148,7 +148,7 @@ ActiveRecord::Schema.define(version: 2021_01_24_192202) do
     t.boolean "is_sticky"
   end
 
-  create_table "reports", id: :integer, options: "ENGINE=MyISAM DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "reports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "person_id"
     t.integer "requester_id"
     t.string "hit_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,35 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_05_222914) do
+ActiveRecord::Schema.define(version: 2021_12_05_223503) do
 
-  create_table "aliases", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "aliases", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "requester_id"
     t.integer "formerly"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "report_id"
     t.integer "person_id"
-    t.text "body"
+    t.text "body", size: :medium
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text "notes"
-    t.text "displayed_notes"
+    t.text "notes", size: :medium
+    t.text "displayed_notes", size: :medium
   end
 
-  create_table "flags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "flags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "report_id"
     t.integer "person_id"
-    t.text "comment"
+    t.text "comment", size: :medium
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text "displayed_notes"
+    t.text "displayed_notes", size: :medium
   end
 
-  create_table "follows", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "follows", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
     t.string "follow_type"
     t.integer "follow_id"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 2021_12_05_222914) do
     t.datetime "updated_at"
   end
 
-  create_table "forum_person_info", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "forum_person_info", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
     t.decimal "karma", precision: 5, scale: 2
     t.string "mail_forum_notifications"
@@ -54,18 +54,18 @@ ActiveRecord::Schema.define(version: 2021_12_05_222914) do
     t.datetime "updated_at"
   end
 
-  create_table "forum_post_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "forum_post_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "post_id"
     t.string "ip"
-    t.text "title"
-    t.text "body"
+    t.text "title", size: :medium
+    t.text "body", size: :medium
     t.integer "next"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "person_id"
   end
 
-  create_table "forum_posts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "forum_posts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
     t.integer "parent_id"
     t.string "slug"
@@ -84,24 +84,24 @@ ActiveRecord::Schema.define(version: 2021_12_05_222914) do
     t.decimal "initial_score", precision: 5, scale: 2
   end
 
-  create_table "ignores", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "ignores", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
     t.integer "report_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
-    t.text "title"
-    t.text "body"
+    t.text "title", size: :medium
+    t.text "body", size: :medium
     t.boolean "read"
     t.datetime "read_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email"
     t.string "hashed_password"
     t.string "salt"
@@ -137,22 +137,22 @@ ActiveRecord::Schema.define(version: 2021_12_05_222914) do
     t.string "confirmation_token"
   end
 
-  create_table "posts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "posts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
     t.integer "parent_id"
-    t.text "title"
-    t.text "body"
+    t.text "title", size: :medium
+    t.text "body", size: :medium
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "slug"
     t.boolean "is_sticky"
   end
 
-  create_table "reports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "reports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
     t.integer "requester_id"
     t.string "hit_id"
-    t.text "description"
+    t.text "description", size: :medium
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "how_many_hits"
@@ -164,13 +164,13 @@ ActiveRecord::Schema.define(version: 2021_12_05_222914) do
     t.boolean "is_hidden"
     t.boolean "tos_viol"
     t.string "amzn_requester_id"
-    t.text "displayed_notes"
+    t.text "displayed_notes", size: :medium
     t.string "amzn_requester_name"
     t.integer "flag_count"
     t.integer "comment_count"
     t.string "ip"
     t.integer "ignore_count", default: 0
-    t.text "hit_names"
+    t.text "hit_names", size: :medium
     t.boolean "dont_censor"
     t.string "rejected"
     t.boolean "locked"
@@ -181,7 +181,7 @@ ActiveRecord::Schema.define(version: 2021_12_05_222914) do
     t.index ["requester_id"], name: "requester_id_index"
   end
 
-  create_table "reputation_statements", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "reputation_statements", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
     t.integer "post_id"
     t.string "statement"
@@ -191,7 +191,7 @@ ActiveRecord::Schema.define(version: 2021_12_05_222914) do
     t.string "ip"
   end
 
-  create_table "requesters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "requesters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "amzn_requester_id"
     t.string "amzn_requester_name"
     t.datetime "created_at"
@@ -212,13 +212,13 @@ ActiveRecord::Schema.define(version: 2021_12_05_222914) do
     t.index ["amzn_requester_id"], name: "amzn_requester_id_index"
   end
 
-  create_table "rules_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "rules_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "parent_id"
     t.boolean "is_current"
     t.integer "edited_by_person_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text "body"
+    t.text "body", size: :medium
   end
 
 end


### PR DESCRIPTION
* Reports table was still MyISAM (old storage engine, doesn't support transactions, ...)
  * We couldn't do this before because we have a full text index on that table and InnoDB didn't support full text indices in MySQL 5.5 (which we were using up until recently)
    * It seems like we don't actually use the full text search functionality but that's a matter for another time
* Convert all tables to the utf8mb4 character set which supports a wide variety of non-latin characters (including emoji)